### PR TITLE
Added 'placeholder' property

### DIFF
--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -2,6 +2,7 @@
   <div class="trix-container">
     <trix-editor
       :input="inputId || randomId"
+      :placeholder="placeholder"
       class="trix-content"
       ref="trix"
       @trix-change="update"
@@ -39,6 +40,13 @@ export default {
   },
   props: {
     inputId: {
+      type: String,
+      required: false,
+      default () {
+        return ''
+      }
+    },
+    placeholder: {
       type: String,
       required: false,
       default () {


### PR DESCRIPTION
Placeholders are supported by the trix editor: https://github.com/basecamp/trix#creating-an-editor

> Like an HTML <textarea>, <trix-editor> accepts autofocus and **placeholder** attributes. Unlike a <textarea>, <trix-editor> automatically expands vertically to fit its contents.

Thanks for the great component by the way! 😄