### PR TITLE
fix: support Firefox under 6.2

### DIFF
--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -73,7 +73,7 @@ export default {
   },
   methods: {
     handleContentChange (event) {
-      this.editorContent = event.srcElement.innerHTML
+      this.editorContent = event.srcElement?event.srcElement.innerHTML:event.target.innerHTML
     },
     emitEditorState (val) {
       if (this.localStorage) {


### PR DESCRIPTION
In special cases, use "event.target" instead of "event.srcElement"