### PR TITLE
Adding Mixins for Trix Editor Events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6131,12 +6131,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6151,17 +6153,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6278,7 +6283,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6290,6 +6296,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6304,6 +6311,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6311,12 +6319,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6335,6 +6345,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6415,7 +6426,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6427,6 +6439,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6548,6 +6561,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -25,15 +25,21 @@
 import 'trix'
 import 'trix/dist/trix.css'
 import EmitFileAccept from '../mixins/EmitFileAccept.js'
+import EmitInitialize from '../mixins/EmitInitialize.js'
 import EmitAttachmentAdd from '../mixins/EmitAttachmentAdd.js'
+import EmitSelectionChange from '../mixins/EmitSelectionChange.js'
 import EmitAttachmentRemove from '../mixins/EmitAttachmentRemove.js'
+import EmitBeforeInitialize from '../mixins/EmitBeforeInitialize.js'
 
 export default {
   name: 'VueTrix',
   mixins: [
     EmitFileAccept('VueTrix'),
+    EmitInitialize('VueTrix'),
     EmitAttachmentAdd('VueTrix'),
-    EmitAttachmentRemove('VueTrix')
+    EmitSelectionChange('VueTrix'),
+    EmitAttachmentRemove('VueTrix'),
+    EmitBeforeInitialize('VueTrix')
   ],
   model: {
     prop: 'srcContent',
@@ -114,7 +120,7 @@ export default {
     }
   },
   created () {
-    /** 
+    /**
      *  If localStorage is enabled,
      *  then load editor's content from the beginning.
      */

--- a/src/mixins/EmitBeforeInitialize.js
+++ b/src/mixins/EmitBeforeInitialize.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {*} component
+ */
+export default function (component) {
+  return {
+    methods: {
+      emitBeforeInitialize (event) {
+        this.$emit('trix-before-initialize', this.$refs.trix.editor, event)
+      }
+    }
+  }
+}

--- a/src/mixins/EmitInitialize.js
+++ b/src/mixins/EmitInitialize.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {*} component
+ */
+export default function (component) {
+  return {
+    methods: {
+      emitInitialize (editor) {
+        this.$emit('trix-initialize', this.$refs.trix.editor, event)
+      }
+    }
+  }
+}

--- a/src/mixins/EmitSelectionChange.js
+++ b/src/mixins/EmitSelectionChange.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {*} component
+ */
+export default function (component) {
+  return {
+    methods: {
+      emitBlur (event) {
+        this.$emit('trix-selection-change', this.$refs.trix.editor, event)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR proposes to add 3 events of the **trix editor** as mixins:

- trixInitialize
- trixBeforeInitialize
- trixSelectionChange

As they are important for setup up bootstrap code (boilerplate) for initializing the editor differently as one prefers