### PR TITLE
Enable option to select content from disabled editors

### DIFF
--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -194,7 +194,7 @@ export default {
       /** Disable toolbar and editor by pointer events styling */
       if (editorState) {
         this.$refs.trix.toolbarElement.style['pointer-events'] = 'none'
-        this.$refs.trix.style['pointer-events'] = 'none'
+        this.$refs.trix.contentEditable = false
         this.$refs.trix.style['background'] = '#e9ecef'
       } else {
         this.$refs.trix.toolbarElement.style['pointer-events'] = 'unset'


### PR DESCRIPTION
I think it makes more sense to let users copy content from editors, even though the editor is disabled.

Since `pointer-events` disable the option to select content, I've changed it for disabling the `content-editable`  attribute.