### PR TITLE
Support autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Add `VueTrix` component into `*.vue` template
 - `inputId`: This is referenced `id` of the hidden input field defined, it is optional.
 - `inputName`: This is referenced `name` of the hidden input field defined, default value is `content`.
 - `placeholder`: The placeholder option attribute specifies a short hint that describes the expected value of a editor.
+- `autofocus`: Automatically focus the editor when it loads
 - `disabledEditor`: This prop will put the editor in read-only mode.
 - `localStorage`: The boolean attribute allows saving editor state into browser's localStorage (optional, default is `false`).
 

--- a/example/src/components/Editor.vue
+++ b/example/src/components/Editor.vue
@@ -4,6 +4,7 @@
       <h2>1. A simple text editor</h2>
       <VueTrix
         localStorage
+        autofocus
         v-model="content1"
         placeholder="Enter your content"
         @trix-file-accept="handleFile"

--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -11,7 +11,7 @@
       @trix-attachment-add="emitAttachmentAdd"
       @trix-attachment-remove="emitAttachmentRemove"
       @trix-selection-change="emitSelectionChange"
-      @trix-initialize="emitInitialize"
+      @trix-initialize="handleInitialize"
       @trix-before-initialize="emitBeforeInitialize"
       @trix-focus="processTrixFocus"
       @trix-blur="processTrixBlur"
@@ -142,14 +142,6 @@ export default {
           this.$refs.trix.editor.loadJSON(JSON.parse(savedValue))
         }
       }
-
-      /**
-       * If autofocus is true, manually set focus to
-       * beginning of content (consistent with Trix behavior)
-       */
-      if (this.autofocus) {
-        this.$refs.trix.editor.setSelectedRange(0)
-      }
     })
   },
   data () {
@@ -162,6 +154,17 @@ export default {
     handleContentChange (event) {
       this.editorContent = event.srcElement ? event.srcElement.value : event.target.value
       this.$emit('input', this.editorContent)
+    },
+    handleInitialize (event) {
+      /**
+       * If autofocus is true, manually set focus to
+       * beginning of content (consistent with Trix behavior)
+       */
+      if (this.autofocus) {
+        this.$refs.trix.editor.setSelectedRange(0)
+      }
+
+      this.$emit('trix-initialize', this.emitInitialize)
     },
     handleInitialContentChange (newContent, oldContent) {
       newContent = newContent === undefined ? '' : newContent

--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -115,6 +115,17 @@ export default {
       default () {
         return false
       }
+    },
+    /**
+     * Focuses cursor in the editor when attached to the DOM
+     * (optional, default is `false`).
+     */
+    autofocus: {
+      type: Boolean,
+      required: false,
+      default () {
+        return false
+      }
     }
   },
   mounted () {
@@ -130,6 +141,14 @@ export default {
         if (savedValue && !this.srcContent) {
           this.$refs.trix.editor.loadJSON(JSON.parse(savedValue))
         }
+      }
+
+      /**
+       * If autofocus is true, manually set focus to
+       * beginning of content (consistent with Trix behavior)
+       */
+      if (this.autofocus) {
+        this.$refs.trix.editor.setSelectedRange(0)
       }
     })
   },

--- a/tests/unit/VueTrix.spec.js
+++ b/tests/unit/VueTrix.spec.js
@@ -26,7 +26,8 @@ describe('VueTrix.vue', () => {
       inputName: 'content',
       placeholder: 'placeholder',
       srcContent: 'srcContent',
-      localStorage: true
+      localStorage: true,
+      autofocus: true
     }
 
     const wrapper = shallowMount(VueTrix, { propsData })
@@ -63,7 +64,8 @@ describe('VueTrix.vue', () => {
         inputId: 'inputId',
         inputName: 'content',
         initContent: 'initContent',
-        placeholder: 'placeholder'
+        placeholder: 'placeholder',
+        autofocus: true
       }
     })
 
@@ -74,6 +76,7 @@ describe('VueTrix.vue', () => {
     expect(trixWrapper.attributes().class).toBe('trix-content')
     expect(trixWrapper.attributes().role).toBe('textbox')
     expect(trixWrapper.attributes().placeholder).toBe('placeholder')
+    expect(trixWrapper.attributes().autofocus).toBe('true')
   })
 
   it('works with v-model directive', () => {

--- a/tests/unit/VueTrix.spec.js
+++ b/tests/unit/VueTrix.spec.js
@@ -64,8 +64,7 @@ describe('VueTrix.vue', () => {
         inputId: 'inputId',
         inputName: 'content',
         initContent: 'initContent',
-        placeholder: 'placeholder',
-        autofocus: true
+        placeholder: 'placeholder'
       }
     })
 
@@ -76,7 +75,6 @@ describe('VueTrix.vue', () => {
     expect(trixWrapper.attributes().class).toBe('trix-content')
     expect(trixWrapper.attributes().role).toBe('textbox')
     expect(trixWrapper.attributes().placeholder).toBe('placeholder')
-    expect(trixWrapper.attributes().autofocus).toBe('true')
   })
 
   it('works with v-model directive', () => {


### PR DESCRIPTION
`vue-trix` was missing support for the `autofocus` attribute (which [Trix supports](https://github.com/basecamp/trix#creating-an-editor)).

These changes are pretty straightforward, except for some reason it doesn't work if we simply using v-bind on the `trix-editor` element itself. 

The only way I could get this working properly was to manually set focus in the editor during the `trix-initialize` event. You'll notice I added a method `handleInitialize` which contains this logic and emits the event.

When focused, the cursor will be placed at the beginning of the content. This behavior is consistent with how Trix does it by default.