### PR TITLE
Re-emit trix-action-invoke events

### DIFF
--- a/src/components/VueTrix.vue
+++ b/src/components/VueTrix.vue
@@ -11,6 +11,7 @@
       @trix-attachment-add="emitAttachmentAdd"
       @trix-attachment-remove="emitAttachmentRemove"
       @trix-selection-change="emitSelectionChange"
+      @trix-action-invoke="emitActionInvoke"
       @trix-initialize="handleInitialize"
       @trix-before-initialize="emitBeforeInitialize"
       @trix-focus="processTrixFocus"
@@ -34,6 +35,7 @@ import EmitAttachmentAdd from '../mixins/EmitAttachmentAdd.js'
 import EmitSelectionChange from '../mixins/EmitSelectionChange.js'
 import EmitAttachmentRemove from '../mixins/EmitAttachmentRemove.js'
 import EmitBeforeInitialize from '../mixins/EmitBeforeInitialize.js'
+import EmitActionInvoke from '../mixins/EmitActionInvoke.js'
 import ProcessEditorFocusAndBlur from '../mixins/ProcessEditorFocusAndBlur.js'
 
 export default {
@@ -45,6 +47,7 @@ export default {
     EmitSelectionChange(),
     EmitAttachmentRemove(),
     EmitBeforeInitialize(),
+    EmitActionInvoke(),
     ProcessEditorFocusAndBlur()
   ],
   model: {

--- a/src/mixins/EmitActionInvoke.js
+++ b/src/mixins/EmitActionInvoke.js
@@ -1,0 +1,13 @@
+/**
+ *
+ * @param {*} component
+ */
+export default function (component) {
+  return {
+    methods: {
+      emitActionInvoke (event) {
+        this.$emit('trix-action-invoke', event)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Enhances the VueTrix component to listen for `trix-action-invoke` events from the `trix-editor`, and re-emit them.

This type of event may be emitted when certain extra buttons are added to the toolbar, as described in [the Trix configuration guide](https://github.com/basecamp/trix/wiki/Configuration).